### PR TITLE
Copy arrays as JSON

### DIFF
--- a/lib/postgres_to_redshift/column.rb
+++ b/lib/postgres_to_redshift/column.rb
@@ -46,6 +46,8 @@
 class PostgresToRedshift::Column
   attr_accessor :attributes
 
+  ARRAY_TYPE = 'array'.freeze
+
   CAST_TYPES_FOR_COPY = {
     "text" => "CHARACTER VARYING(65535)",
     "json" => "CHARACTER VARYING(65535)",
@@ -55,7 +57,7 @@ class PostgresToRedshift::Column
     "inet" => "CHARACTER VARYING(65535)",
     "array" => "CHARACTER VARYING(65535)",
     "uuid" => "CHARACTER VARYING(65535)",
-    }
+  }
 
   def initialize(attributes: )
     self.attributes = attributes
@@ -66,7 +68,9 @@ class PostgresToRedshift::Column
   end
 
   def name_for_copy
-    if needs_type_cast?
+    if data_type.downcase == ARRAY_TYPE
+      %Q[CAST(array_to_json("#{name}") AS #{data_type_for_copy}) AS #{name}]
+    elsif needs_type_cast?
       %Q[CAST("#{name}" AS #{data_type_for_copy}) AS #{name}]
     else
       %Q["#{name}"]

--- a/spec/lib/postgres_to_redshift/column_spec.rb
+++ b/spec/lib/postgres_to_redshift/column_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe PostgresToRedshift::Column do
       expect(column.data_type_for_copy).to eq("CHARACTER VARYING(65535)")
     end
 
-    it 'casts array to character varying' do
+    it 'casts array to character varying, as JSON' do
       attributes = {
         "table_catalog"            => "postgres_to_redshift",
         "table_schema"             => "public",
@@ -177,6 +177,9 @@ RSpec.describe PostgresToRedshift::Column do
 
       column = PostgresToRedshift::Column.new attributes: attributes
       expect(column.data_type_for_copy).to eq("CHARACTER VARYING(65535)")
+      expect(column.name_for_copy).to eq(
+        %q{CAST(array_to_json("description") AS CHARACTER VARYING(65535)) AS description}
+      )
     end
 
     it 'casts uuid to character varying' do


### PR DESCRIPTION
Redshift can't handle arrays, but it can kinda deal with JSON...ish. So it's helpful if we copy arrays in JSON format.